### PR TITLE
Preserve empty lines in code blocks

### DIFF
--- a/gh-pages-stub/public/js/utils.js
+++ b/gh-pages-stub/public/js/utils.js
@@ -49,7 +49,7 @@ var UTILS = (function () {
 	}
 
 	my.splitByLines = function splitByLines(text) {
-		return text.match(/[^\r\n]+/g);
+		return text.split("\n");
 	}
 
 	my.getVersionFromURL = function getVersionFromURL() {


### PR DESCRIPTION
When jekvers tries to insert expand button, it splits lines by
matching only non-empty lines. This leads to all empty lines to be
omitted when button is inserted.

Split by '\n' instead, so there is no empty lines discrimination.