### PR TITLE
JEK-29: Revert

### DIFF
--- a/gh-pages-stub/_config.yml
+++ b/gh-pages-stub/_config.yml
@@ -32,4 +32,4 @@ kramdown:
   enable_coderay: false
   entity_output:  as_char
   hard_wrap: false
-  syntax_highlighter: none
+  syntax_highlighter: rouge


### PR DESCRIPTION
The original issue is likely caused by inappropriate code block
language selection, and should be not resolved in a such a radical way
as dropping syntax highlighting for all blocks.